### PR TITLE
Bisecting the failure

### DIFF
--- a/.github/workflows/ni.yml
+++ b/.github/workflows/ni.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        jdk: [21, 24]
+        jdk: [21, 22, 23, 24]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
We know that 
- GraalVM 21 works fine
- GraalVM 24 fails
- what's the cause of the failure?

Let's "bisect" the versions!